### PR TITLE
Install rsync to fetch docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN dnf install -y docker \
                    python3-devel \
                    python3-libselinux \
                    python3-jmespath \
-                   python3-pip ; \
+                   python3-pip \
+                   rsync ; \
     dnf clean all
 
 ADD requirements.txt /requirements.txt


### PR DESCRIPTION
Install `rsync` in the docker file to be able to use `pre_build_image: no`.